### PR TITLE
Feat/concat func improve speed

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,15 +21,13 @@ import (
 )
 
 // Concat Function responsible for abstracting the build function and delivering
-// The result will be  Concat(int, []int, []int32, []string, string)
+// The result will be  Concat(int, []int, []int32, []string, string, bool, reflect.Value(string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64))
 func Concat(str ...interface{}) string {
 	return Build(str...)
 }
 
-//ConcatFunc will be responsible for concatenating the function's return into a string.
-//nil return parameters are ignored.
-//parameters with valid errors are still triggered and must be corrected.
-func ConcatFunc(f ...interface{}) string {
+// ConcatFuncOLD is deprecated.
+func ConcatFuncOLD(f ...interface{}) string {
 	var tmp string
 
 	for _, val := range f {
@@ -53,8 +51,25 @@ func ConcatFunc(f ...interface{}) string {
 	return string(tmp)
 }
 
+// ConcatFunc will be responsible for concatenating the function's return into a string.
+// nil return parameters are ignored.
+// parameters with valid errors are still triggered and must be corrected.
+func ConcatFunc(f ...interface{}) string {
+	var tmpS strings.Builder
+	for _, val := range f {
+		switch v := val.(type) {
+		case nil, func(), struct{}:
+		case error:
+			tmpS.WriteString(v.Error())
+		default: // TODO REMOVE WHEN buildStr1 to buildStr4 be capable of not use reflect package
+			tmpS.WriteString(buildStr5(reflect.ValueOf(v)))
+		}
+	}
+	return tmpS.String()
+}
+
 // Build Function responsible for concatenating, and accepting different types
-// The result will be Build(int, []int, []int32, []string, string)
+// The result will be BuildConcat(int, []int, []int32, []string, string, bool, reflect.Value(string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64))
 func Build(strs ...interface{}) string {
 	// testing various ways to improve
 	// performance is using Builder
@@ -156,11 +171,11 @@ func buildStr3(str interface{}) (concat string) {
 func buildStr4(str interface{}) (concat string) {
 	switch str.(type) {
 	case float64:
-		concat = strconv.FormatFloat(str.(float64), 'f', 6, 64)
+		concat = strconv.FormatFloat(str.(float64), 'f', -1, 64)
 	case []float64:
 		concat = ConcatSliceFloat64(str.([]float64))
 	case float32:
-		concat = strconv.FormatFloat(float64(str.(float32)), 'f', 6, 64)
+		concat = strconv.FormatFloat(float64(str.(float32)), 'f', -1, 64)
 	case []float32:
 		concat = ConcatSliceFloat32(str.([]float32))
 	case uint:
@@ -168,8 +183,132 @@ func buildStr4(str interface{}) (concat string) {
 	case []uint:
 		concat = ConcatSliceUint(str.([]uint))
 	default:
-		concat = "<not exist type without suport>"
+		concat = buildStr5(str)
 	}
+	return
+}
+
+// buildStr5 Function responsible abstracting cases where interface is reflect.Value
+// buildStr5( string, result func(), bool, slice,array, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64)
+func buildStr5(str interface{}) (concat string) {
+	switch str.(type) {
+	case reflect.Value:
+		v := str.(reflect.Value)
+		k := v.Kind()
+		if k == reflect.Bool {
+			if v.Interface().(bool) {
+				concat = "true"
+				return
+			}
+			concat = "false"
+			return
+		}
+		if k == reflect.Int {
+			concat = strconv.FormatInt(int64(v.Interface().(int)), 10)
+			return
+		}
+		if k == reflect.Int8 {
+			concat = strconv.FormatInt(int64(v.Interface().(int8)), 10)
+			return
+		}
+		if k == reflect.Int16 {
+			concat = strconv.FormatInt(int64(v.Interface().(int16)), 10)
+			return
+		}
+		if k == reflect.Int32 {
+			concat = strconv.FormatInt(int64(v.Interface().(int32)), 10)
+			return
+		}
+		if k == reflect.Int64 {
+			concat = strconv.FormatInt(v.Interface().(int64), 10)
+			return
+		}
+		if k == reflect.Uint {
+			concat = strconv.FormatUint(uint64(v.Interface().(uint)), 10)
+			return
+		}
+		if k == reflect.Uint8 {
+			concat = strconv.FormatUint(uint64(v.Interface().(uint8)), 10)
+			return
+		}
+		if k == reflect.Uint16 {
+			concat = strconv.FormatUint(uint64(v.Interface().(uint16)), 10)
+			return
+		}
+		if k == reflect.Uint32 {
+			concat = strconv.FormatUint(uint64(v.Interface().(uint32)), 10)
+			return
+		}
+		if k == reflect.Uint64 {
+			concat = strconv.FormatUint(v.Interface().(uint64), 10)
+			return
+		}
+		if k == reflect.Float32 {
+			concat = strconv.FormatFloat(float64(v.Interface().(float32)), 'f', -1, 64)
+			return
+		}
+		if k == reflect.Float64 {
+			concat = strconv.FormatFloat(v.Interface().(float64), 'f', -1, 64)
+			return
+		}
+		if k == reflect.String {
+			concat = v.Interface().(string)
+			return
+		}
+		if k == reflect.Slice {
+			var tmp strings.Builder
+			for i := 0; i < v.Len(); i++ {
+				tmp.WriteString(Build(v.Index(i)))
+			}
+			concat = tmp.String()
+			return
+		}
+		if k == reflect.Array {
+			var tmp strings.Builder
+			for i := 0; i < v.Len(); i++ {
+				tmp.WriteString(Build(v.Index(i)))
+			}
+			concat = tmp.String()
+			return
+		}
+		if k == reflect.Func { // calling back buildStr5 to run over reflect types
+			var tmp strings.Builder
+			s := v.Call([]reflect.Value{})
+			for i := 0; i < len(s); i++ {
+				tmp.WriteString(buildStr5(s[i]))
+			}
+			concat = tmp.String()
+			return
+		}
+		// TODO REMOVE when new handling of reflect type arrives
+		concat = fmt.Sprint(v)
+		return
+		/* TODO
+		if k == reflect.Struct {
+			var tmp strings.Builder
+			for i := 0; i < v.NumField(); i++ { // calling back buildStr5 to run over reflect types
+				tmp.WriteString(buildStr5(v.Field(i)))
+			}
+			concat = tmp.String()
+			return
+		}
+		if k == reflect.Interface {
+		}
+		if k == reflect.Map {
+		}
+		if k == reflect.Pointer {
+		}
+		if k == reflect.Uintptr {
+		}
+		*/
+	default: // case the reflect type isn't already reflect.Value, we reflect the type and call the function again.
+		concat = buildStr5(reflect.ValueOf(str))
+		if concat == "" {
+			break
+		}
+		return
+	}
+	concat = "<not exist type without suport>"
 	return
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,7 @@ func ExampleConcat() {
 	s := Concat("/api/v1/", 39383838, "/", 129494, "/product/", 2012)
 	s = Concat(s, ":", 33.22, []string{" - ", "jeffotoni", "-", "2021"})
 	fmt.Println(s)
-	// Output: /api/v1/39383838/129494/product/2012:33.220000 - jeffotoni-2021
+	// Output: /api/v1/39383838/129494/product/2012:33.22 - jeffotoni-2021
 }
 
 // This function is named ExampleBuild()
@@ -210,7 +210,7 @@ func TestConcatFuncMany(t *testing.T) {
 	}
 }
 
-//go test -v -run ^TestConcatFuncNil
+// go test -v -run ^TestConcatFuncNil
 func TestConcatFuncNil(t *testing.T) {
 	typeNil := func() interface{} {
 		return nil
@@ -221,7 +221,7 @@ func TestConcatFuncNil(t *testing.T) {
 	}
 }
 
-//go test -v -run ^TestConcatFuncError
+// go test -v -run ^TestConcatFuncError
 func TestConcatFuncError(t *testing.T) {
 	typeError := func() error {
 		return errors.New("error")
@@ -519,7 +519,7 @@ func TestUIntTypes(t *testing.T) {
 	}
 }
 
-//go test -v -run ^TestConcatSliceBool
+// go test -v -run ^TestConcatSliceBool
 func TestConcatSliceBool(t *testing.T) {
 	//[]bool empty
 	var be []bool
@@ -535,7 +535,7 @@ func TestConcatSliceBool(t *testing.T) {
 	}
 }
 
-//go test -v -run ^TestConcatFloats
+// go test -v -run ^TestConcatFloats
 func TestConcatFloats(t *testing.T) {
 	//[]float32 empty
 	var ef32 []float32
@@ -612,19 +612,19 @@ func TestConcatMany(t *testing.T) {
 	// float32
 	var f32 float32 = float32(23)
 	sf32 := Concat(f32)
-	if sf32 != "23.000000" {
+	if sf32 != "23" {
 		t.Errorf("Error TestConcatMany for float32: %v, want %v", sf32, "23.000000")
 	}
 	// float64
 	var f64 float64 = float64(23)
 	sf64 := Concat(f64)
-	if sf64 != "23.000000" {
+	if sf64 != "23" {
 		t.Errorf("Error TestConcatMany for float64: %v, want %v", su16, "23.000000")
 	}
 
 }
 
-//go test -v -run ^Test_Concat_OneStr
+// go test -v -run ^Test_Concat_OneStr
 func Test_Concat_OneStr(t *testing.T) {
 	var many1String, many1Int, many1Int8, many1Int16, many1Int32, many1Int64 interface{}
 	var many1Uint, many1Uint8, many1Uint16, many1Uint32, many1Uint64 interface{}
@@ -656,7 +656,6 @@ func Test_Concat_OneStr(t *testing.T) {
 		args args
 		want string
 	}{
-		// TODO: Add test cases.
 		{"test_ConcatStr_", args{str: many1String}, "21"},
 		{"test_ConcatStr_", args{str: many1Int}, "100"},
 		{"test_ConcatStr_", args{str: many1Int8}, "100"},
@@ -691,7 +690,7 @@ func Test_Concat_OneStr(t *testing.T) {
 	}
 }
 
-//go test -v -run ^Test_Concat_Many
+// go test -v -run ^Test_Concat_Many
 func Test_Concat_Many(t *testing.T) {
 
 	var many1String, many1Int, many1Int8, many1Int16, many1Int32, many1Int64 []interface{}
@@ -908,4 +907,101 @@ func BenchmarkMarshal(b *testing.B) {
 			panic(err)
 		}
 	}
+}
+
+// go test -v -failfast -run ^TestConcatFunc$
+func TestConcatFunc(t *testing.T) {
+	type args struct {
+		f []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				f: []interface{}{
+					func(a, b, c int) int {
+						return a + b*c
+					}(1, 2, 3),
+				},
+			},
+			want: "7",
+		},
+		{
+			name: "test with function as result",
+			args: args{
+				f: []interface{}{
+					func(a, b, c int) func() int {
+						return func() int { x := 0; return x }
+					}(1, 2, 3),
+				},
+			},
+			want: "0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConcatFunc(tt.args.f...); got != tt.want {
+				t.Errorf("ConcatFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var concatFuncResp string
+
+func BenchmarkConcatFunc(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		concatFuncResp = ConcatFunc(func(a, b, c int) int {
+			return a + b*c
+		}(1, 2, 3), []int{1, 2, 3, 4})
+	}
+
+}
+
+// go test -v -failfast -run ^TestConcatFuncOLD$
+func TestConcatFuncOLD(t *testing.T) {
+	type args struct {
+		f []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				f: []interface{}{
+					func(a, b, c int) int {
+						return a + b*c
+					}(1, 2, 3),
+				},
+			},
+			want: "7",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConcatFuncOLD(tt.args.f...); got != tt.want {
+				t.Errorf("ConcatFuncOLD() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var concatFuncRespOLD string
+
+func BenchmarkConcatFuncOLD(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		concatFuncRespOLD = ConcatFuncOLD(func(a, b, c int) int {
+			return a + b*c
+		}(1, 2, 3), []int{1, 2, 3, 4})
+	}
+
 }


### PR DESCRIPTION
**Performance improve of ConcatFunc and add support for reflect package.** 
This also enables support for digest others functions and concatenate the result into one string, example : 
`
	x:=func(a, b, c int) func() int {
						return func() int { x := 0; return x }
	}(1, 2, 3),
`
 **This also fix bad usage of FormatFloat, where the decimal cases was fixed into  6, now with -1 it will use the necessary cases to accurate return the representing float..**

![image](https://user-images.githubusercontent.com/39197618/194681667-5cb02fb5-1722-47cd-ba58-b70a7aeb284c.png)
Tests executed on VMBOX 
CPU Cores set to 2 on VMBOX.
